### PR TITLE
feat: show drive connection status in popup

### DIFF
--- a/chatgpt-md-export/popup.html
+++ b/chatgpt-md-export/popup.html
@@ -5,6 +5,7 @@
     <h3 style="margin:8px 0;">ChatGPT → Markdown</h3>
     <button id="save">Save current chat (.md)</button>
     <p style="opacity:.7">단축키: Ctrl/⌘+Shift+Y</p>
+    <p>Google Drive 연결: <span id="authStatus">확인 중...</span></p>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/chatgpt-md-export/popup.js
+++ b/chatgpt-md-export/popup.js
@@ -2,3 +2,14 @@ document.getElementById('save').addEventListener('click', () => {
   chrome.runtime.sendMessage({ type: 'REQUEST_SAVE' });
   window.close();
 });
+
+function renderAuthStatus(auth) {
+  const now = Math.floor(Date.now() / 1000);
+  const ok = !!auth?.access_token && auth.expires_at > now + 60;
+  document.getElementById('authStatus').textContent = ok ? '연결됨' : '미연결';
+}
+
+(async () => {
+  const { cfg = {} } = await chrome.storage.sync.get({ cfg: {} });
+  renderAuthStatus(cfg.auth || {});
+})();


### PR DESCRIPTION
## Summary
- display Google Drive auth connection status in popup
- load stored credentials and render status text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b407e702c48322894e902a591c5a1c